### PR TITLE
add script that opens links in new tab

### DIFF
--- a/dotorg/README.md
+++ b/dotorg/README.md
@@ -11,3 +11,7 @@ A twin to .org Helper. The script runs in the .org forums for Modern Tribe plugi
 ## Sample screenshot of dotorg-helper
 
 ![image](https://dl.dropbox.com/s/cr3sqlwd04s9dnq/shot_210910_182623.jpg)
+
+## `dotorg-open-links-new-tab.js`
+
+This causes all links you click on to open in a new tab.

--- a/dotorg/dotorg-open-links-new-tab.js
+++ b/dotorg/dotorg-open-links-new-tab.js
@@ -6,6 +6,7 @@
 // @author       You
 // @match        https://wordpress.org/support/plugin/the-events-calendar*
 // @include      https://wordpress.org/support/topic*
+// @include      https://wordpress.org/support/plugin/event-tickets*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=wordpress.org
 // @grant        none
 // ==/UserScript==

--- a/dotorg/dotorg-open-links-new-tab.js
+++ b/dotorg/dotorg-open-links-new-tab.js
@@ -1,0 +1,21 @@
+// ==UserScript==
+// @name         Opens all links in new tab
+// @namespace    http://tampermonkey.net/
+// @version      0.1
+// @description  This adds target="_blank" to all <a> tags
+// @author       You
+// @match        https://wordpress.org/support/plugin/the-events-calendar*
+// @include      https://wordpress.org/support/topic*
+// @icon         https://www.google.com/s2/favicons?sz=64&domain=wordpress.org
+// @grant        none
+// ==/UserScript==
+
+(function() {
+    'use strict';
+    const links = document.querySelectorAll("a");
+
+    links.forEach( (link)=> {
+        link.target="_blank";
+    })
+
+})();

--- a/dotorg/dotorg-open-links-new-tab.js
+++ b/dotorg/dotorg-open-links-new-tab.js
@@ -4,7 +4,7 @@
 // @version      0.1
 // @description  This adds target="_blank" to all <a> tags
 // @author       You
-// @match        https://wordpress.org/support/plugin/the-events-calendar*
+// @include        https://wordpress.org/support/plugin/the-events-calendar*
 // @include      https://wordpress.org/support/topic*
 // @include      https://wordpress.org/support/plugin/event-tickets*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=wordpress.org

--- a/dotorg/dotorg-open-links-new-tab.js
+++ b/dotorg/dotorg-open-links-new-tab.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Opens all links in new tab
-// @namespace    http://tampermonkey.net/
+// @namespace    https://theeventscalendar.com
 // @version      0.1
 // @description  This adds target="_blank" to all <a> tags
 // @author       James Welbes

--- a/dotorg/dotorg-open-links-new-tab.js
+++ b/dotorg/dotorg-open-links-new-tab.js
@@ -3,11 +3,13 @@
 // @namespace    http://tampermonkey.net/
 // @version      0.1
 // @description  This adds target="_blank" to all <a> tags
-// @author       You
-// @include        https://wordpress.org/support/plugin/the-events-calendar*
+// @author       James Welbes
+// @include      https://wordpress.org/support/plugin/the-events-calendar*
 // @include      https://wordpress.org/support/topic*
 // @include      https://wordpress.org/support/plugin/event-tickets*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=wordpress.org
+// @downloadURL  https://github.com/the-events-calendar/tampermonkey-scripts/raw/main/dotorg/dotorg-open-links-new-tab.js
+// @updateURL    https://github.com/the-events-calendar/tampermonkey-scripts/raw/main/dotorg/dotorg-open-links-new-tab.js
 // @grant        none
 // ==/UserScript==
 


### PR DESCRIPTION
This tampermonkey script adds a simple javascript forEach that adds 'target="_blank"' to all <a> tags on https://wordpress.org/support/topic*